### PR TITLE
use correct syntax for file read to avoid E5108 in nvim

### DIFF
--- a/lua/Navigator/tmux.lua
+++ b/lua/Navigator/tmux.lua
@@ -25,7 +25,7 @@ function T.execute(arg)
     local t_cmd = string.format("tmux -S %s %s", T.get_socket(), arg)
 
     local handle = assert(io.popen(t_cmd), string.format("Navigator: Unable to execute > [%s]", t_cmd))
-    local result = handle:read("l")
+    local result = handle:read("*l")
 
     handle:close()
 


### PR DESCRIPTION
Following error pops up when require("Navigator") command is used with any direction:
`E5108: Error executing lua .../pack/packer/start/Navigator.nvim/lua/Navigator/tmux.lua:28: bad argument #1
 to 'read' (invalid option)`
According to documentation http://www.lua.org/manual/5.1/manual.html#5.7  "*l" option should be passed to file:read() in order to read a new line instead of "l".
Proposed change gets rid of E5108 on tab switch between nvim and tmux