### PR TITLE
fix ignoring passed opts

### DIFF
--- a/lua/Navigator/navigate.lua
+++ b/lua/Navigator/navigate.lua
@@ -20,7 +20,7 @@ function N.setup(opts)
     }
 
     if opts ~= nil then
-        vim.tbl_extend('keep', opts, N.config)
+        N.config = vim.tbl_extend('keep', opts, N.config)
     end
 
     function _G.__navigator_reset_last_pane()


### PR DESCRIPTION
hello, thank you for the plugin!

on nvim 0.6 ( did not checked 0.5 ) `vim.tbl_extend` is not mutating passed tables and just returning new table, so this PR fixes that case for passed config to `setup(opts)`