### PR TITLE
chore!: remove 0.6 support

### DIFF
--- a/lua/Navigator/navigate.lua
+++ b/lua/Navigator/navigate.lua
@@ -31,26 +31,12 @@ function N.setup(opts)
         N.config = vim.tbl_extend('keep', opts, N.config)
     end
 
-    -- NOTE: remove this after 0.7 release
-    if not A.nvim_create_autocmd then
-        function N.reset()
+    A.nvim_create_autocmd('WinEnter', {
+        group = A.nvim_create_augroup('NAVIGATOR', { clear = true }),
+        callback = function()
             N.last_pane = false
-        end
-
-        vim.cmd([[
-            augroup NAVIGATOR
-                au!
-                autocmd WinEnter * lua require("Navigator.navigate").reset()
-            augroup END
-        ]])
-    else
-        A.nvim_create_autocmd('WinEnter', {
-            group = A.nvim_create_augroup('NAVIGATOR', { clear = true }),
-            callback = function()
-                N.last_pane = false
-            end,
-        })
-    end
+        end,
+    })
 end
 
 ---Checks whether we need to move to the nearby tmux pane

--- a/plugin/Navigator.lua
+++ b/plugin/Navigator.lua
@@ -1,20 +1,9 @@
 local ucmd = vim.api.nvim_create_user_command
 
--- NOTE: remove this after 0.7 release
-if not ucmd then
-    vim.cmd([[
-        command NavigatorLeft lua require'Navigator'.left()
-        command NavigatorRight lua require'Navigator'.right()
-        command NavigatorUp lua require'Navigator'.up()
-        command NavigatorDown lua require'Navigator'.down()
-        command NavigatorPrevious lua require'Navigator'.previous()
-    ]])
-else
-    local N = require('Navigator')
+local N = require('Navigator')
 
-    ucmd('NavigatorLeft', N.left, {})
-    ucmd('NavigatorRight', N.right, {})
-    ucmd('NavigatorUp', N.up, {})
-    ucmd('NavigatorDown', N.down, {})
-    ucmd('NavigatorPrevious', N.previous, {})
-end
+ucmd('NavigatorLeft', N.left, {})
+ucmd('NavigatorRight', N.right, {})
+ucmd('NavigatorUp', N.up, {})
+ucmd('NavigatorDown', N.down, {})
+ucmd('NavigatorPrevious', N.previous, {})


### PR DESCRIPTION
This will allow the use of the following Lua API in 0.7

- `nvim_create_user_command` to create user commands
- `nvim_create_{augroup,autocmd}` to create autocommands

---

If you are using 0.6 then please follow the instructions here https://github.com/numToStr/Navigator.nvim/releases/tag/v0.6