### PR TITLE
Add support for running the plugin under tmate

### DIFF
--- a/lua/Navigator/tmux.lua
+++ b/lua/Navigator/tmux.lua
@@ -21,11 +21,18 @@ local function get_socket()
     return vim.split(TMUX, ',')[1]
 end
 
+---To know if we should talk to tmux or tmate
+---@return string
+local function get_executable_name()
+    -- The $TMUX environment variable contains the name of the executable.
+    return TMUX:find "tmate" and "tmate" or "tmux"
+end
+
 ---For executing a tmux command
 ---@param arg string Tmux command to run
 ---@return number
 local function execute(arg)
-    local t_cmd = string.format('tmux -S %s %s', get_socket(), arg)
+    local t_cmd = string.format('%s -S %s %s', get_executable_name(), get_socket(), arg)
 
     local handle = assert(io.popen(t_cmd), string.format('Navigator: Unable to execute > [%s]', t_cmd))
     local result = handle:read()

--- a/lua/Navigator/tmux.lua
+++ b/lua/Navigator/tmux.lua
@@ -25,7 +25,7 @@ end
 ---@return string
 local function get_executable_name()
     -- The $TMUX environment variable contains the name of the executable.
-    return TMUX:find "tmate" and "tmate" or "tmux"
+    return TMUX:find('tmate') and 'tmate' or 'tmux'
 end
 
 ---For executing a tmux command


### PR DESCRIPTION
Previously, using this plugin in a tmate session would cause it to output `server version is too old for client` and hang the pane.

This change makes it so that the plugin knows to talk to the tmate executable rather than tmux when necessary.