### PR TITLE
Prohibit error message for unnamed buffers

### DIFF
--- a/lua/Navigator/navigate.lua
+++ b/lua/Navigator/navigate.lua
@@ -88,9 +88,11 @@ function N.navigate(direction)
 
         local save = N.config.auto_save
         if save == 'current' then
-            cmd('update')
+            if vim.fn.expand('%') ~= '' then
+              cmd('update')
+            end
         elseif save == 'all' then
-            cmd('wall')
+            cmd('silent! wall')
         end
 
         N.last_pane = true


### PR DESCRIPTION
In case a buffer has no name, vim raises an error message if the file has no filename given.