### PR TITLE
Add WezTerm zoom support

### DIFF
--- a/lua/Navigator/mux/wezterm.lua
+++ b/lua/Navigator/mux/wezterm.lua
@@ -41,6 +41,22 @@ function WezTerm:new()
     return setmetatable(state, self)
 end
 
+---Checks if wezterm is zoomed in
+---@return boolean
+function WezTerm:zoomed()
+    local ok, panes = pcall(vim.json.decode, self.execute('list --format json'))
+    if not ok then
+      return false
+    end
+    local active_pane_id = tonumber(os.getenv('WEZTERM_PANE'))
+    for _, pane in ipairs(panes) do
+      if pane.pane_id == active_pane_id then
+        return pane.is_zoomed
+      end
+    end
+    return false
+end
+
 ---Switch pane in wezterm
 ---@param direction Direction See |navigator.api.Direction|
 ---@return WezTerm

--- a/lua/Navigator/utils.lua
+++ b/lua/Navigator/utils.lua
@@ -5,7 +5,7 @@ local U = {}
 ---@return unknown
 function U.execute(cmd)
     local handle = assert(io.popen(cmd), string.format('[Navigator] Unable to execute cmd - %q', cmd))
-    local result = handle:read()
+    local result = handle:read("*a")
     handle:close()
     return result
 end


### PR DESCRIPTION
Hi, this change aims to add WezTerm:zoomed(), similar to Tmux:zoomed().

The reason why I went with that cryptic regex is that I did not want to introduce a `jq` dependency to the plugin, while usually `grep` can be found on every computer. I am not sure about whether this would work on Windows, but I guess if somebody wants it, they can also create a pull request for it.