### PR TITLE
fix(utils): redirect stderr so it doesn't leak

### DIFF
--- a/lua/Navigator/utils.lua
+++ b/lua/Navigator/utils.lua
@@ -4,7 +4,7 @@ local U = {}
 ---@param cmd string
 ---@return unknown
 function U.execute(cmd)
-    local handle = assert(io.popen(cmd), string.format('[Navigator] Unable to execute cmd - %q', cmd))
+    local handle = assert(io.popen(cmd .. " 2>&1"), string.format('[Navigator] Unable to execute cmd - %q', cmd))
     local result = handle:read()
     handle:close()
     return result

--- a/lua/Navigator/utils.lua
+++ b/lua/Navigator/utils.lua
@@ -4,20 +4,27 @@ local U = {}
 ---@param cmd string
 ---@return unknown
 function U.execute(cmd)
-    local handle = assert(io.popen(cmd .. " 2>&1"), string.format('[Navigator] Unable to execute cmd - %q', cmd))
+    local handle = assert(io.popen(cmd .. ' 2>&1'), string.format('[Navigator] Unable to execute cmd - %q', cmd))
     local result = handle:read()
     handle:close()
     return result
 end
 
----Returns executable suffix based on platform
----@return string
-function U.suffix()
-    local uname = vim.loop.os_uname()
-    if string.find(uname.release, 'WSL.*$') or string.find(uname.sysname, '^Win') then
-        return '.exe'
+local suffix_cache = nil
+--Returns executable suffix based on platform
+--- REF: Navigator.nvim
+--@return string
+U.suffix = function()
+    if not suffix_cache then
+        suffix_cache = '' -- default to empty, overwrite if it's windows
+        local uname = vim.loop.os_uname()
+        if string.find(uname.release, 'WSL.*$') or string.find(uname.sysname, '^Win') then -- may be windows
+            if os.execute('wezterm.exe') == 0 then -- if exe exists, execute if expensive so heuristics first
+                suffix_cache = '.exe'
+            end
+        end
+        return suffix_cache
     end
-    return ''
 end
 
 return U

--- a/lua/Navigator/utils.lua
+++ b/lua/Navigator/utils.lua
@@ -4,27 +4,24 @@ local U = {}
 ---@param cmd string
 ---@return unknown
 function U.execute(cmd)
-    local handle = assert(io.popen(cmd .. ' 2>&1'), string.format('[Navigator] Unable to execute cmd - %q', cmd))
+    local handle = assert(io.popen(cmd .. '>/dev/null 2>&1'), string.format('[Navigator] Unable to execute cmd - %q', cmd))
     local result = handle:read()
     handle:close()
     return result
 end
 
 local suffix_cache = nil
---Returns executable suffix based on platform
---- REF: Navigator.nvim
---@return string
+---Returns executable suffix based on platform
+---@return string
 U.suffix = function()
-    if not suffix_cache then
-        suffix_cache = '' -- default to empty, overwrite if it's windows
-        local uname = vim.loop.os_uname()
-        if string.find(uname.release, 'WSL.*$') or string.find(uname.sysname, '^Win') then -- may be windows
-            if os.execute('wezterm.exe') == 0 then -- if exe exists, execute if expensive so heuristics first
-                suffix_cache = '.exe'
-            end
-        end
-        return suffix_cache
-    end
+	if not suffix_cache then
+		suffix_cache = '' -- default to empty, overwrite if it's windows
+		local obj = vim.system({ 'wezterm.exe', '--help' }):wait() -- if exe exists
+		if obj.code == 0 then
+			suffix_cache = '.exe'
+		end
+	end
+	return suffix_cache
 end
 
 return U


### PR DESCRIPTION
Due to https://github.com/neovim/neovim/issues/21376 you get the following `read failed 11: Resource temporarily unavailable`:

![image](https://github.com/numToStr/Navigator.nvim/assets/51170833/5404ac3b-5f35-4538-99a9-c3b9710505d3)

whenever you switch wezterm panes. In the example I spammed left-right, but in practice it appears once and only sometimes.

This works around the issue by redirecting stderr to stdout.
