### PR TITLE
feat: add support for Zellij

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ vim.keymap.set({'n', 't'}, '<A-p>', '<CMD>NavigatorPrevious<CR>')
 
 - [Tmux](https://github.com/numToStr/Navigator.nvim/wiki/Tmux-Integration)
 - [WezTerm](https://github.com/numToStr/Navigator.nvim/wiki/WezTerm-Integration)
+- [Zellj](https://github.com/numToStr/Navigator.nvim/wiki/Zellij-Integration)
 
 #### Configuration (optional)
 

--- a/lua/Navigator/mux/zellij.lua
+++ b/lua/Navigator/mux/zellij.lua
@@ -34,8 +34,8 @@ function Zellij:new()
         direction = {
             p = 'focus-previous-pane',
             h = 'move-focus-or-tab left',
-            j = 'move-focus-or-tab down',
-            k = 'move-focus-or-tab up',
+            j = 'move-focus down',
+            k = 'move-focus up',
             l = 'move-focus-or-tab right',
         },
     }

--- a/lua/Navigator/mux/zellij.lua
+++ b/lua/Navigator/mux/zellij.lua
@@ -1,0 +1,54 @@
+---@mod navigator.zellij Zellij navigator
+---@brief [[
+---This module provides navigation and interaction for Zellij, and uses |navigator.vi|
+---as a base class. This is used automatically when zellij is detected on host
+---system but can also be used to manually override the mux.
+---Read also: https://github.com/numToStr/Navigator.nvim/wiki/Zellij-Integration
+---@brief ]]
+
+---@private
+---@class Zellij: Vi
+---@field private direction table<Direction, string>
+---@field private execute fun(arg: string): unknown
+local Zellij = require('Navigator.mux.vi'):new()
+
+---Creates a new Zellij navigator instance
+---@return Zellij
+---@usage [[
+---local ok, zellij = pcall(function()
+---    return require('Navigator.mux.zellij'):new()
+---end)
+---
+---require('Navigator').setup({
+---    mux = ok and zellij or 'auto'
+---})
+---@usage ]]
+function Zellij:new()
+    assert(os.getenv('ZELLIJ'), '[Navigator] Zellij is not running!')
+
+    ---@type Zellij
+    local state = {
+        execute = function(arg)
+            return require('Navigator.utils').execute(string.format('zellij action %s', arg))
+        end,
+        direction = {
+            p = 'focus-previous-pane',
+            h = 'move-focus-or-tab left',
+            j = 'move-focus-or-tab down',
+            k = 'move-focus-or-tab up',
+            l = 'move-focus-or-tab right',
+        },
+    }
+    self.__index = self
+    return setmetatable(state, self)
+end
+
+---Switch pane in zellij
+---@param direction Direction See |navigator.api.Direction|
+---@return Zellij
+function Zellij:navigate(direction)
+    self.execute(string.format("%s", self.direction[direction]))
+    return self
+end
+
+return Zellij

--- a/lua/Navigator/navigate.lua
+++ b/lua/Navigator/navigate.lua
@@ -13,6 +13,12 @@ local N = {
 ---Detect and load correct mux
 ---@return Vi
 local function load_mux()
+    local ok_zellij, zellij = pcall(function()
+        return require('Navigator.mux.zellij'):new()
+    end)
+    if ok_zellij then
+        return zellij
+    end
     local ok_tmux, tmux = pcall(function()
         return require('Navigator.mux.tmux'):new()
     end)


### PR DESCRIPTION
I'm considering about adding to the same wiki page that shows wezterm
instructions.
Zellij has already default keybindings with <Alt> key, but not support fully seamlessly navigate.(https://github.com/zellij-org/zellij/issues/967)